### PR TITLE
Adds in an alternative follow up page

### DIFF
--- a/entrytool/templates/detail/alt_followups.html
+++ b/entrytool/templates/detail/alt_followups.html
@@ -1,0 +1,66 @@
+{% load i18n %}
+<div class="follow-up-table" ng-show="episode.follow_up.length > 0">
+<span ng-repeat="item in episode.follow_up | orderBy: '-follow_up_date' as follow_ups"></span>
+  <div class="col-md-12">
+    <div class="row header-row display-label">
+      <div class="col-sm-3 header"></div>
+      <div ng-show="$index < episode.follow_up.length" class="col-sm-1 header" ng-repeat="not_used in [].constructor(8) track by $index">
+        <span ng-show="$index < episode.follow_up.length">
+          [[ follow_ups[$index].hospital | translate ]]
+          <br />
+          [[ follow_ups[$index].follow_up_date | displayDate ]]
+          <br>
+          <i style="font-size: 14px;" ng-click="episode.recordEditor.editItem('{{ models.FollowUp.get_api_name }}', follow_ups[$index])" class="fa fa-pencil edit pointer"></i>
+        </span>
+      </div>
+    </div>
+    <div class="row table-row" >
+      <div class="col-sm-3 first-column text-right">{% trans "LDH" %}</div>
+      <div class="col-sm-1 column" ng-repeat="not_used in [].constructor(8) track by $index">
+        [[ follow_ups[$index].LDH ]]
+      </div>
+    </div>
+    <div class="row table-row" >
+      <div class="col-sm-3 first-column text-right">{% trans "Beta2m" %}</div>
+      <div class="col-sm-1 column" ng-repeat="not_used in [].constructor(8) track by $index">
+        [[ follow_ups[$index].beta2m ]]
+      </div>
+    </div>
+    <div class="row table-row" >
+      <div class="col-sm-3 first-column text-right">{% trans "Albumin" %}</div>
+      <div class="col-sm-1 column" ng-repeat="not_used in [].constructor(8) track by $index">
+        [[ follow_ups[$index].albumin ]]
+      </div>
+    </div>
+    <div class="row table-row" >
+      <div class="col-sm-3 first-column text-right">{% trans "Creatinin" %}</div>
+      <div class="col-sm-1 column" ng-repeat="not_used in [].constructor(8) track by $index">
+        [[ follow_ups[$index].creatinin ]]
+      </div>
+    </div>
+    <div class="row table-row" >
+      <div class="col-sm-3 first-column text-right">{% trans "MCV" %}</div>
+      <div class="col-sm-1 column" ng-repeat="not_used in [].constructor(8) track by $index">
+        [[ follow_ups[$index].MCV ]]
+      </div>
+    </div>
+    <div class="row table-row" >
+      <div class="col-sm-3 first-column text-right">{% trans "Hb" %}</div>
+      <div class="col-sm-1 column" ng-repeat="not_used in [].constructor(8) track by $index">
+        [[ follow_ups[$index].Hb ]]
+      </div>
+    </div>
+    <div class="row table-row" >
+      <div class="col-sm-3 first-column text-right">&#922;/&#923; Ratio</div>
+      <div class="col-sm-1 column" ng-repeat="not_used in [].constructor(8) track by $index">
+        [[ follow_ups[$index].kappa_lambda_ratio ]]
+      </div>
+    </div>
+    <div class="row table-row" >
+      <div class="col-sm-3 first-column text-right">{% trans "Bone Lesions" %}</div>
+      <div class="col-sm-1 column" ng-repeat="not_used in [].constructor(8) track by $index">
+        [[ follow_ups[$index].bone_lesions ]]
+      </div>
+    </div>
+  </div>
+</div>


### PR DESCRIPTION
@WoutV so this offers an alternative follow up view by date across the top for the last 8 results. If you want to use it, merge it and replace in patient_detail.html replace ` {% include "detail/followups.html" %}` with ` {% include "detail/alt_followups.html" %}`

![Screen Shot 2020-10-09 at 13 41 38](https://user-images.githubusercontent.com/2175455/95584235-43162000-0a35-11eb-9577-0d0de733c7fd.png)
