### PR TITLE
There used to be a patient details record category that was 2/3rds of…

### DIFF
--- a/entrytool/templates/records/patient_status.html
+++ b/entrytool/templates/records/patient_status.html
@@ -17,10 +17,10 @@
   <ul class="list-group">
     <li class="list-group-patient.patient_status[0]">
       <div class="row">
-   <div class="col-md-2">
+   <div class="col-md-6">
     <span ng-show="patient.patient_status[0].lost_to_follow_up_date" class="display-label">{% trans "Last Seen" %}</span>
   </div>
-  <div class="col-md-2">
+  <div class="col-md-6">
     <span ng-show="patient.patient_status[0].lost_to_follow_up_date">
     [[ patient.patient_status[0].lost_to_follow_up_date | displayDate ]]
     </span>
@@ -28,12 +28,12 @@
 </div>
 
 <div class="row">
-  <div class="col-md-2">
+  <div class="col-md-6">
     <span ng-show="patient.patient_status[0].death_date || patient.patient_status[0].death_cause">
       <span class="display-label">{% trans "Death details" %}</span>
     </span>
   </div>
-  <div class="col-md-2">
+  <div class="col-md-6">
     <span ng-show="patient.patient_status[0].death_date || patient.patient_status[0].death_cause">
       [[ patient.patient_status[0].death_date | displayDate ]] ([[ patient.patient_status[0].death_cause | translate ]])
     </span>

--- a/plugins/conditions/cll/templates/records/cll_diagnosis_details.html
+++ b/plugins/conditions/cll/templates/records/cll_diagnosis_details.html
@@ -1,25 +1,27 @@
 {% load i18n %}
 <div class="row">
-  <div class="col-md-4">
+  <div class="col-md-6">
     <span class="display-label">{% trans "Date of Diagnosis" %}</span>
   </div>
-  <div class="col-md-4">
+  <div class="col-md-6">
     [[ item.diag_date | displayDate ]]
   </div>
 
 </div>
 
 <div class="row">
-  <div class="col-md-4">
+  <div class="col-md-6">
     <span class="display-label">{% trans "Binet Stage" %}</span>
   </div>
-  <div class="col-md-4">
+  <div class="col-md-6">
     [[ item.binet_stage | translate ]]
   </div>
-   <div class="col-md-2">
+</div>
+<div class="row">
+   <div class="col-md-6">
     <span ng-show="item.lost_to_follow_up_date" class="display-label">{% trans "Last Seen" %}</span>
   </div>
-  <div class="col-md-2">
+  <div class="col-md-6">
     <span ng-show="item.lost_to_follow_up_date">
     [[ item.lost_to_follow_up_date | displayDate ]]
     </span>
@@ -27,12 +29,12 @@
 </div>
 
 <div class="row">
-  <div class="col-md-2">
+  <div class="col-md-6">
     <span ng-show="item.death_date || item.death_cause">
       <span class="display-label">{% trans "Death details" %}</span>
     </span>
   </div>
-  <div class="col-md-2">
+  <div class="col-md-6">
     <span ng-show="item.death_date || item.death_cause">
       [[ item.death_date | displayDate ]] ([[ item.death_cause | translate ]])
     </span>


### PR DESCRIPTION
… a page. There are now 2 models, patient status and diagnosis details. The record panels should stop trying to show things fields data in a format that expects a larger record panel and instead just show field: value on a new row.

Patient details was 2/3rds of a page, so the template represented that, ie it was
<img width="1388" alt="Screenshot 2022-02-23 at 17 04 35" src="https://user-images.githubusercontent.com/2175455/155369565-5ca27c41-2490-48c6-a4ad-dc56defc1e11.png">

Now it is two different panels so the panel html code needs to show this, ie is now
<img width="1386" alt="Screenshot 2022-02-23 at 17 02 16" src="https://user-images.githubusercontent.com/2175455/155369727-75724f3b-8ad5-4c8e-aed4-110ee1a215bd.png">


