### PR TITLE
Move the header into the condition category template so that we can set the category name in the header

### DIFF
--- a/entrytool/templates/patient_detail.html
+++ b/entrytool/templates/patient_detail.html
@@ -8,29 +8,28 @@
   </p>
 </div>
 <div ng-controller="PatientValidator"></div>
-<div class="entry-tool container-fluid content-offset " ng-hide="patient == null">
-  <div class=" panel panel-primary panel-container patient-detail">
-    <!-- Default panel contents -->
-    <div class="panel-heading patient-detail-heading">
-      <h2>
-       {% trans "Patient" %} [[ patient.id ]]
-      </h2>
-    </div>
-
-    <div class="panel-body">
-
-      <div ng-repeat="episode in patient.episodes" class="row">
-        {% for episode_category in episode_categories %}
-        {% if episode_category.detail_template and not episode_category.display_name == 'Inpatient' %}
-        <div ng-show='episode.category_name === "{{ episode_category.display_name }}"' class="col-md-12 padding0">
-          {% include episode_category.detail_template %}
+  <div ng-repeat="episode in patient.episodes">
+    {% for episode_category in episode_categories %}
+    {% if episode_category.detail_template and not episode_category.display_name == 'Inpatient' %}
+    <div ng-show='episode.category_name === "{{ episode_category.display_name }}"' class="entry-tool container-fluid content-offset">
+      <div class=" panel panel-primary panel-container patient-detail">
+        <!-- Default panel contents -->
+        <div class="panel-heading patient-detail-heading">
+          <h2>
+            {% trans "Patient" %} [[ patient.id ]] ([[ episode.category_name ]])
+          </h2>
         </div>
-        {% endif %}
-        {% endfor %}
+        <div class="panel-body">
+          <div class="row">
+            <div class="col-md-12 padding0">
+              {% include episode_category.detail_template %}
+            </div>
+          </div>
+        </div>
       </div>
     </div>
-    <!-- Panel body -->
+    {% endif %}
+    {% endfor %}
   </div>
-  <!-- Panel -->
 </div>
 <!-- Container -->

--- a/entrytool/templates/patient_detail.html
+++ b/entrytool/templates/patient_detail.html
@@ -2,39 +2,24 @@
 <div ng-show="patient == null" class="container-fluid content-offset">
   <h1 class="text-center content-offset">{% trans "Patient not found" %}</h1>
   <p class="lead text-center content-offset">
-    {% trans "We're sorry but we couldn't find the patient you're looking for."
-    %}
+    {% trans "We're sorry but we couldn't find the patient you're looking for." %}
     <br />
     {% trans "Perhaps try searching for them instead?" %}
   </p>
 </div>
-<div
-  class="
-    entry-tool
-    container-fluid
-    content-offset
-    {% block container_classes %}{% endblock %}
-  "
-  ng-hide="patient == null"
->
-  <div
-    class="
-      panel panel-primary panel-container
-      patient-detail
-      {% block panel_classes %}{% endblock %}
-    "
-  >
+<div ng-controller="PatientValidator"></div>
+<div class="entry-tool container-fluid content-offset " ng-hide="patient == null">
+  <div class=" panel panel-primary panel-container patient-detail">
     <!-- Default panel contents -->
     <div class="panel-heading patient-detail-heading">
       <h2>
-        {% block heading %}{% trans "Patient" %} [[ patient.id ]]{% endblock %}
+       {% trans "Patient" %} [[ patient.id ]]
       </h2>
     </div>
 
-    <div class="panel-body {% block panel_body_classes %}{% endblock %}">
-      <div ng-controller="PatientValidator"></div>
+    <div class="panel-body">
+
       <div ng-repeat="episode in patient.episodes" class="row">
-        {% block content %}
         {% for episode_category in episode_categories %}
         {% if episode_category.detail_template and not episode_category.display_name == 'Inpatient' %}
         <div ng-show='episode.category_name === "{{ episode_category.display_name }}"' class="col-md-12 padding0">
@@ -42,7 +27,6 @@
         </div>
         {% endif %}
         {% endfor %}
-        {% endblock content %}
       </div>
     </div>
     <!-- Panel body -->


### PR DESCRIPTION
This...
* fixes a bug, the django template tag for the first {% trans %} was on multiple lines so was not working and was print {% trans on the screen.
* removes the template tag blocks, we don't extend this template in the app so this was just noise
* moves the patient header. e.g. Patient 1 into the ng-repeat episode iterator so that we can show Patient 1 (CLL)
![Screenshot 2022-02-24 at 15 25 18](https://user-images.githubusercontent.com/2175455/155554409-7b4ebc94-ad3b-4885-95bf-c12fffa4a27e.png)

