### PR TITLE
Change the entrytool helper to not check episode category for regimen…

### DIFF
--- a/entrytool/static/js/entrytool/services/entrytool_helper.js
+++ b/entrytool/static/js/entrytool/services/entrytool_helper.js
@@ -42,10 +42,10 @@ angular.module('opal.services').factory('EntrytoolHelper', function() {
 			*
 			* This returns the regimen, no matter what the condition is
 			*/
-			if(episode.category_name === CLL){
+			if(episode.cll_regimen.length){
 				return episode.cll_regimen
 			}
-			else if(episode.category_name === MM){
+			else if(episode.mm_regimen.length){
 				return episode.mm_regimen
 			}
 			return [];
@@ -58,10 +58,10 @@ angular.module('opal.services').factory('EntrytoolHelper', function() {
 			*
 			* This returns the responses, no matter what the condition is
 			*/
-			if(episode.category_name === CLL){
+			if(episode.best_response.length){
 				return episode.best_response
 			}
-			else if(episode.category_name === MM){
+			else if(episode.mm_response.length){
 				return episode.mm_response
 			}
 			return [];


### PR DESCRIPTION
A previous change was in error, I had forgotten that the regimen sit on the Line Of Treatment episode category which is used by multiple conditions so checking the episode category does not actually tell you the name of the regimen/response. This rolls back that change.