### PR TITLE
Line of treatment episode order

### DIFF
--- a/entrytool/static/js/entrytool/controllers/lot_manager.js
+++ b/entrytool/static/js/entrytool/controllers/lot_manager.js
@@ -63,7 +63,9 @@ angular.module('opal.controllers').controller(
         return regimen.start_date
       });
       if(!regimens.length){
-        return 0;
+        // if there are no regimens return a date in the far future so this LOT
+        // appears first
+        return moment(new Date(9000, 0, 1));
       }
       return regimens[0].start_date;
     };

--- a/entrytool/static/js/entrytool/controllers/lot_manager.js
+++ b/entrytool/static/js/entrytool/controllers/lot_manager.js
@@ -67,7 +67,7 @@ angular.module('opal.controllers').controller(
         // appears first
         return moment(new Date(9000, 0, 1));
       }
-      return _.last(regimens).start_date;
+      return regimens[0].start_date;
     };
   }
 );

--- a/entrytool/static/js/entrytool/controllers/lot_manager.js
+++ b/entrytool/static/js/entrytool/controllers/lot_manager.js
@@ -63,9 +63,7 @@ angular.module('opal.controllers').controller(
         return regimen.start_date
       });
       if(!regimens.length){
-        // if there are no regimens return a date in the far future so this LOT
-        // appears first
-        return moment(new Date(9000, 0, 1));
+        return 0;
       }
       return regimens[0].start_date;
     };

--- a/entrytool/static/js/entrytool/controllers/lot_manager.js
+++ b/entrytool/static/js/entrytool/controllers/lot_manager.js
@@ -67,7 +67,7 @@ angular.module('opal.controllers').controller(
         // appears first
         return moment(new Date(9000, 0, 1));
       }
-      return regimens[0].start_date;
+      return _.last(regimens).start_date;
     };
   }
 );

--- a/entrytool/static/js/entrytool/controllers/lot_manager.js
+++ b/entrytool/static/js/entrytool/controllers/lot_manager.js
@@ -59,13 +59,13 @@ angular.module('opal.controllers').controller(
       * Orders the line of treatments in the patient detail page
       * by the earliest regimen date of that episode.
       */
-      var regiments = _.sortBy(lot.regimen, function(regimen){
+      var regimens = _.sortBy(lot.regimen, function(regimen){
         return regimen.start_date
       });
-      if(!regiments.length){
+      if(!regimens.length){
         return 0;
       }
-      return regiments[0].start_date;
+      return regimens[0].start_date;
     };
   }
 );

--- a/entrytool/static/js/entrytool/controllers/lot_manager.js
+++ b/entrytool/static/js/entrytool/controllers/lot_manager.js
@@ -1,5 +1,5 @@
 angular.module('opal.controllers').controller(
-  "LineOfTreatmentManager", function($scope, $http, $q, $modal, UserProfile){
+  "LineOfTreatmentManager", function($scope, $http, $q, $modal, UserProfile, EntrytoolHelper){
     "use strict";
     var self = this;
     this.loading = false;
@@ -59,7 +59,7 @@ angular.module('opal.controllers').controller(
       * Orders the line of treatments in the patient detail page
       * by the earliest regimen date of that episode.
       */
-      var regimens = _.sortBy(lot.regimen, function(regimen){
+      var regimens = _.sortBy(EntrytoolHelper.getEpisodeRegimen(lot), function(regimen){
         return regimen.start_date
       });
       if(!regimens.length){

--- a/plugins/conditions/cll/templates/detail/cll.html
+++ b/plugins/conditions/cll/templates/detail/cll.html
@@ -36,6 +36,10 @@
           diagnosis or progression till start of treatment after subsequent
           progression
         </div>
+        <div class="help-block">
+          Info: you might be confused by the treatment line order when adding a
+          new line. After you save, they will be in the correct order.
+        </div>
         <div
           class="row"
           ng-repeat="episode in patient.episodes | filter: { category_name: 'Treatment Line' } | orderBy:lineOfTreatmentManager.lineOfTreatmentOrder:true as lot_episodes"

--- a/plugins/conditions/cll/templates/detail/cll.html
+++ b/plugins/conditions/cll/templates/detail/cll.html
@@ -36,10 +36,6 @@
           diagnosis or progression till start of treatment after subsequent
           progression
         </div>
-        <div class="help-block">
-          Info: you might be confused by the treatment line order when adding a
-          new line. After you save, they will be in the correct order.
-        </div>
         <div
           class="row"
           ng-repeat="episode in patient.episodes | filter: { category_name: 'Treatment Line' } | orderBy:lineOfTreatmentManager.lineOfTreatmentOrder:true as lot_episodes"


### PR DESCRIPTION
I haven't been able to duplicate the behavour described by the comment. In fact given ordering is always done by javascript reloading should not matter.

My theory are the problem could be one of 2...

1. The previous code ordered by earliest regimen per line of treatment descending. This reorders by latest regim instead. IE if you have one LOT with a regimen starting at 5 Feb, another LOT with regimens starting at 1 Feb and 10 Feb. The previous method puts the 5 Feb above the 1 Feb/10 Feb. The new method puts the 1 Feb/10 Feb first.

2. LOT with no regimens were added to the bottom. This would be unintuitive as its more likely they would add new LOT first, so I've changed it so LOT with no regimens appear at the top of the list.