### PR TITLE
Adds in a default episode category. 

### DIFF
--- a/entrytool/__init__.py
+++ b/entrytool/__init__.py
@@ -3,10 +3,11 @@ entrytool - Our Opal Application
 """
 from opal.core import application
 from opal.core import menus
-from plugins.conditions.cll.episode_categories import CLLCondition
+from entrytool import episode_categories
 
 from django.utils.translation import gettext_lazy as _
 from django.urls import reverse
+
 
 class Application(application.OpalApplication):
     javascripts   = [
@@ -24,7 +25,7 @@ class Application(application.OpalApplication):
         "css/entrytool.css"
     ]
 
-    default_episode_category = CLLCondition.display_name
+    default_episode_category = episode_categories.Default.display_name
 
     @classmethod
     def get_menu_items(klass, user=None):

--- a/entrytool/episode_categories.py
+++ b/entrytool/episode_categories.py
@@ -1,5 +1,20 @@
 from opal.core import episodes
 
 
+class Default(episodes.EpisodeCategory):
+    """
+    This is the default episode category of any episode.
+
+    It exists because, in Opal, an episode must have an
+    episode_category.
+
+    In this application the pathway to add an episode should
+    always assign a condition category e.g. MM or CLL after the
+    episode has been created. IE we should not see any episodes
+    with this category name.
+    """
+    display_name = "Default"
+
+
 class LineOfTreatmentEpisode(episodes.EpisodeCategory):
     display_name = "Treatment Line"

--- a/entrytool/episode_categories.py
+++ b/entrytool/episode_categories.py
@@ -5,13 +5,16 @@ class Default(episodes.EpisodeCategory):
     """
     This is the default episode category of any episode.
 
-    It exists because, in Opal, an episode must have an
-    episode_category.
+    In Opal, an episode must have a value in the field `category_name` 
+    that relates to an `EpisodeCategory` class.
 
-    In this application the pathway to add an episode should
-    always assign a condition category e.g. MM or CLL after the
-    episode has been created. IE we should not see any episodes
-    with this category name.
+    In this application any episode that is initially assigned the
+    default at episode creation time should then be assigned to the
+    appropriate category e.g. an MM or CLL episode before the transaction
+    commits.
+
+    Any episodes that exist in the database with 'Default' as their
+    `category_name` likely exist in error and should be investigated.
     """
     display_name = "Default"
 

--- a/entrytool/pathways.py
+++ b/entrytool/pathways.py
@@ -5,7 +5,7 @@ from opal.core.episodes import (
     EpisodeCategory, InpatientEpisode
 )
 from entrytool import models
-from entrytool.episode_categories import LineOfTreatmentEpisode
+from entrytool.episode_categories import LineOfTreatmentEpisode, Default
 from django.utils.translation import gettext_lazy as _
 
 category_select_step = Step(
@@ -45,7 +45,9 @@ class AddPatient(PagePathway):
         from the category select step.
         """
         non_conditions = (
-            LineOfTreatmentEpisode.display_name, InpatientEpisode.display_name,
+            LineOfTreatmentEpisode.display_name,
+            InpatientEpisode.display_name,
+            Default.display_name,
         )
         return [
             i.display_name for i in EpisodeCategory.list() if i.display_name not in non_conditions


### PR DESCRIPTION
This PR decouples CLL from the main application.

In theory the entrytool can be used with any condition so CLL should not be explicitly mentioned in the __init__.Application. Instead we use a default episode category that in theory should never be used as after an episode is created by the add patient pathway it should be assigned a condition within the same database transaction.