### PR TITLE
Update the patientValidator.patient reference when we refresh the scope.

### DIFF
--- a/entrytool/static/js/entrytool/controllers/lot_manager.js
+++ b/entrytool/static/js/entrytool/controllers/lot_manager.js
@@ -12,12 +12,25 @@ angular.module('opal.controllers').controller(
       return !this.loading && !this.readonly;
     }
 
+    this.refresh = function(){
+      /*
+      * This wraps the scope.refresh and updates the reference to the patient
+      * on the patient
+      */
+      var deferred = $q.defer();
+      $scope.refresh().then(function(){
+        $scope.$parent.patientValidator.patient = $scope.$parent.patient;
+        deferred.resolve();
+      });
+      return deferred.promise;
+    }
+
     this.create = function(patient){
       this.loading = true;
       var deferred = $q.defer();
       var url = "/entrytool/v0.1/new_line_of_treatment_episode/" + patient.id + "/";
       $http.put(url).then(function(){
-        $scope.refresh().then(function(){
+        self.refresh().then(function(){
           self.loading = false;
           deferred.resolve();
         });
@@ -46,7 +59,7 @@ angular.module('opal.controllers').controller(
       });
       deleteModal.result.then(function(result){
         if(result === "deleted"){
-          $scope.refresh().then(deferred.resolve());
+          self.refresh().then(deferred.resolve());
         }
         else{
           deferred.resolve();


### PR DESCRIPTION
We had a bug where the patient validator was using a stale reference to the patient if $scope.refresh had been called. 

It is only called by the LOT Manager and was happening when you added or deleted episodes.