### PR TITLE
Fix a bug where we were not excluding the current regimen from our calculation of the min max of an episode date.

### DIFF
--- a/entrytool/static/js/entrytool/controllers/patient_validator.js
+++ b/entrytool/static/js/entrytool/controllers/patient_validator.js
@@ -267,21 +267,23 @@ angular
       }
 
       var episodeRegimenMinMaxDates = function (episode) {
+        return getRegimenMinMaxDate(EntrytoolHelper.getEpisodeRegimen(episode));
+      };
+
+      var getRegimenMinMaxDate = function(regimen){
         // returns the first start date and the last end date
         // note end date may be null;
-
         // pluck the regimen start dates, sort them and return the first
-        var episodeMin = _.pluck(EntrytoolHelper.getEpisodeRegimen(episode), "start_date").sort()[0];
-
+        var episodeMin = _.pluck(regimen, "start_date").sort()[0];
         var episodeMax = null;
         // regimen end date is not required, remove the nulls and
         // make sure any of them are populated
-        var episodeMaxVals = _.compact(_.pluck(EntrytoolHelper.getEpisodeRegimen(episode), "end_date"));
+        var episodeMaxVals = _.compact(_.pluck(regimen, "end_date"));
         if (episodeMaxVals.length) {
           episodeMax = _.sortBy(episodeMaxVals).reverse()[0];
         }
         return [episodeMin, episodeMax];
-      };
+      }
 
       var validateRegimenToOtherLOTRegimens = function (
         val,
@@ -295,9 +297,15 @@ angular
         // check vs the instance dates as these may have changed.
         var min = toMomentFilter(instance.start_date);
         var max = toMomentFilter(instance.end_date);
+        var thisEpisodesRegimen = EntrytoolHelper.getEpisodeRegimen(episode)
 
-        if(EntrytoolHelper.getEpisodeRegimen(episode).length){
-          var ourEpisodeMinMax = episodeRegimenMinMaxDates(episode);
+        // exclude this regimen's id if it exists
+        if(instance.id){
+          thisEpisodesRegimen = _.filter(thisEpisodesRegimen, function(r){ return r.id !== instance.id });
+        }
+
+        if(thisEpisodesRegimen.length){
+          var ourEpisodeMinMax = getRegimenMinMaxDate(thisEpisodesRegimen);
           if(ourEpisodeMinMax[0].isBefore(min, "d")){
             min = ourEpisodeMinMax[0];
           }


### PR DESCRIPTION
To reproduce. Create an episode with a regimen that starts and ends on the 2nd of Feb

create a second episode with a regimen that starts and ends on the 6th of feb.

Change the end date of the first regimen to 8th of Feb. 

The min max equation thinks that that episodes regimen start on the 2nd of Feb and ends on the 8th of Feb and a validation error is raised.

This fixes that so we exclude the saved regimen so the validation returns that the episodes new regimen starts and ends on the 8th of Feb