### PR TITLE
Bugfix for when the value is an integer

### DIFF
--- a/entrytool/static/js/entrytool/services/validators.js
+++ b/entrytool/static/js/entrytool/services/validators.js
@@ -446,11 +446,18 @@ angular.module('opal.services').service('Validators', function(EntrytoolHelper, 
 			}
 		},
 		validateInOptions: function(value, instance, episode, patient, apiName, fieldName, schema, lookuplists){
-			if(!value){
+			if(_.isNull(value) || _.isUndefined(value)){
 				return false;
+			}
+			if(_.isString(value) && !value.length){
+				return false
 			}
 			var subRecordSchema = _.findWhere(schema[apiName].fields, {name: fieldName});
 			if(subRecordSchema.enum){
+				// if the subrecord schema are ints, parse the value to an int
+				if(_.isNumber(subRecordSchema.enum[0])){
+					value = parseInt(value);
+				}
 				return !_.contains(subRecordSchema.enum, value)
 			}
 

--- a/entrytool/static/js/tests/test_validators.js
+++ b/entrytool/static/js/tests/test_validators.js
@@ -771,6 +771,54 @@ describe("Validators", function () {
 			)).toBe(false);
 		});
 
+		it("should return false if the value is a string that can be cast to an int and the enums are ints", function(){
+			enum_schema = {
+				diagnosis: {
+					fields: [{
+						name: "some_test",
+						enum: [1, 2, 3],
+					}]
+				}
+			}
+			expect(Validators.validateInOptions(
+				"1", null, null, null, apiName, fieldName, enum_schema, lookuplists
+			)).toBe(false);
+		});
+
+		it("should return true if the value is an int but the enums are strings", function(){
+			enum_schema = {
+				diagnosis: {
+					fields: [{
+						name: "some_test",
+						enum: ["1", "2", "3"],
+					}]
+				}
+			}
+			expect(Validators.validateInOptions(
+				1, null, null, null, apiName, fieldName, enum_schema, lookuplists
+			)).toBe(true);
+		});
+
+		it("should return false if the value is an empty string", function(){
+			expect(Validators.validateInOptions(
+				"", null, null, null, apiName, fieldName, enum_schema, lookuplists
+			)).toBe(false);
+		});
+
+		it("should return true if the value is not in the enum and is 0", function(){
+			enum_schema = {
+				diagnosis: {
+					fields: [{
+						name: "some_test",
+						enum: [1, 2, 3],
+					}]
+				}
+			}
+			expect(Validators.validateInOptions(
+				0, null, null, null, apiName, fieldName, enum_schema, lookuplists
+			)).toBe(true);
+		});
+
 		it("should return true if the value is not in the enum", function(){
 			expect(Validators.validateInOptions(
 				"d", null, null, null, apiName, fieldName, enum_schema, lookuplists


### PR DESCRIPTION
When the model changes angular uses a string as the value. If the enums
are integers make sure we cast the value to an integer when we are doing
out comparison