### PR TITLE
Make the label for bulky disease consistently > 5cm

### DIFF
--- a/plugins/conditions/cll/templates/forms/additional_characteristics_form.html
+++ b/plugins/conditions/cll/templates/forms/additional_characteristics_form.html
@@ -7,4 +7,4 @@
 {% number field="AdditionalCharacteristics.creatinine_clearance" unit="mL/min" %}
 {% number field="AdditionalCharacteristics.LDH" unit="U" label=_("LDH")%}
 {% number field="AdditionalCharacteristics.beta2m" unit="mg/dL" label=_("Beta-2-Microglobulin")%}
-{% radio field="AdditionalCharacteristics.bulky_disease" label=_("Bulky disease >5cm")%}
+{% radio field="AdditionalCharacteristics.bulky_disease" label=_("Bulky disease > 5cm")%}


### PR DESCRIPTION
The form uses "Bulky disease >5cm" the display template uses  "Bulky disease > 5cm".

This makes them both consistently "Bulky disease > 5cm"